### PR TITLE
Support for Building and running on Mac OS X

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ target_compile_options(hack PRIVATE
     -Wno-implicit-function-declaration  # cross-file calls lacking prototypes in hack.h
     -Wno-int-conversion            # alloc() returns char* used as struct pointers
     -Wno-incompatible-pointer-types # g_at() generic pointer casts
-    -fno-pie  # Modern: keep stable data addresses between hack and mklev
+    $<$<NOT:$<PLATFORM_ID:Darwin>>:-fno-pie>  # non-PIE causes trace trap on macOS
     $<$<C_COMPILER_ID:Clang>:-Wno-deprecated-non-prototype>
     $<$<C_COMPILER_ID:Clang>:-Wno-knr-promoted-parameter>
     $<$<C_COMPILER_ID:GNU>:-Wno-maybe-uninitialized>
@@ -85,9 +85,10 @@ target_compile_options(hack PRIVATE
     $<$<CONFIG:Release>:-O2>
 )
 
-target_link_options(hack PRIVATE
-    -no-pie  # Modern: keep stable data addresses between hack and mklev
-)
+# non-PIE linker flag causes trace trap on macOS due to SIP/security enforcement
+if(NOT APPLE)
+    target_link_options(hack PRIVATE -no-pie)
+endif()
 
 target_link_libraries(hack ${CURSES_LIBRARIES})
 # Makes CRYPT_LIB linking conditional - only links it if found. This supports building on 
@@ -121,7 +122,7 @@ target_compile_options(mklev PRIVATE
     -Wno-implicit-function-declaration
     -Wno-int-conversion
     -Wno-incompatible-pointer-types
-    -fno-pie  # Modern: keep stable data addresses between hack and mklev
+    $<$<NOT:$<PLATFORM_ID:Darwin>>:-fno-pie>  # non-PIE causes trace trap on macOS
     $<$<C_COMPILER_ID:Clang>:-Wno-deprecated-non-prototype>
     $<$<C_COMPILER_ID:Clang>:-Wno-knr-promoted-parameter>
     $<$<C_COMPILER_ID:GNU>:-Wno-maybe-uninitialized>
@@ -129,9 +130,10 @@ target_compile_options(mklev PRIVATE
     $<$<CONFIG:Release>:-O2>
 )
 
-target_link_options(mklev PRIVATE
-    -no-pie  # Modern: keep stable data addresses between hack and mklev
-)
+# non-PIE linker flag causes trace trap on macOS due to SIP/security enforcement
+if(NOT APPLE)
+    target_link_options(mklev PRIVATE -no-pie)
+endif()
 
 # =========================================================================
 # hackdir setup — automates READ_ME steps 2-5

--- a/src/root/hack.main.c
+++ b/src/root/hack.main.c
@@ -4,7 +4,7 @@
 #include "../compat.h"
 #include "hack.vars"
 
-char lock[11] = "alock";	/* long enough for login name */
+char lock[64] = "alock";	/* Modern: increased from 11 to fit longer usernames */
 /* note that lock is also used for temp file names */
 #ifdef SIGWINCH
 /* MODERN ADDITION (2026): Terminal resize protection for modern WM events

--- a/src/root/hack.vars
+++ b/src/root/hack.vars
@@ -49,7 +49,7 @@ char NOCOLD[]="You don't feel cold!";
 char DONTH[]="You don't have that.";
 
 #ifndef SMALL
-char SAVEF[13]="save/";
+char SAVEF[64]="save/";  /* Modern: increased from 13 to fit longer usernames */
 #endif
 
 struct permonst mon[8][7] = {


### PR DESCRIPTION
Hi there, feel free to discard all of this!

* Ignores CRYPT_LIB as magic call is in std c lib on Mac OS X
* Adds support for longer usernames that was causing a crash

I'm certainly no longer a C/compiler tools hacker but was curious to see if I could get this up and running in a Mac OS X environment.  End result is that I can run the game successfully in a Mac OS X terminal or iTerm etc.  I have _not_ tested properly for Linux x86-64 or other platform regressions, happy to lend a hand with GitHub Actions work if that helps.